### PR TITLE
Fix usage of Kount API in Data Collector after Kount updates

### DIFF
--- a/Editor/LinqDependencies.xml
+++ b/Editor/LinqDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
   <iosPods>
-    <iosPod name="Kount">
+    <iosPod name="Kount" version="4.1.10">
       <sources>
         <source>https://github.com/Kount/kount-pod-spec</source>
       </sources>

--- a/Plugins/iOS/DataCollector.m
+++ b/Plugins/iOS/DataCollector.m
@@ -21,7 +21,7 @@ void _Init(sessionCallBackDelegate delegate, const char* kountClientId, const bo
     }
 
     // Set your Merchant ID
-    [[KDataCollector sharedCollector] setMerchantID:[stringFromChar(kountClientId) integerValue]];
+    [[KDataCollector sharedCollector] setMerchantID:stringFromChar(kountClientId)];
 
     // Set the location collection configuration
     [[KDataCollector sharedCollector]setLocationCollectorConfig:KLocationCollectorConfigRequestPermission];
@@ -42,7 +42,7 @@ void _Collect() {
                 if (error != nil) {
                     NSLog([@(error.code) stringValue], error.description, error);
                 } else {
-                    NSLog(@"0", @"Unknown kount error", nil);
+                    NSLog(@0, @"Unknown kount error", nil);
                 }
             }
         }];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gg.linq.unity-sdk",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "license": "MIT",
   "displayName": "LinQ Unity",
   "description": "LinQ SDK for Unity",


### PR DESCRIPTION
- **Lock Kount pods version to prevent braking builds**
- **Update DataCollector plugin to correspond Kount updated version**
